### PR TITLE
Add cluster export for subnet ids in Cloudformation

### DIFF
--- a/lib/components/common-utilities.ts
+++ b/lib/components/common-utilities.ts
@@ -3,6 +3,7 @@ import {EngineVersion} from "aws-cdk-lib/aws-opensearchservice";
 import {Secret} from "aws-cdk-lib/aws-secretsmanager";
 import {CdkLogger} from "./cdk-logger";
 import {Construct} from "constructs";
+import {SubnetSelection} from "aws-cdk-lib/aws-ec2";
 
 export const MAX_STAGE_NAME_LENGTH = 15;
 export const MAX_CLUSTER_ID_LENGTH = 15;
@@ -54,12 +55,20 @@ export function createBasicAuthSecret(scope: Construct, username: string, passwo
     })
 }
 
-export function generateClusterExports(scope: Construct, clusterEndpoint: string, clusterId: string, stage: string, clusterAccessSecurityGroupId?: string) {
+export function generateClusterExports(scope: Construct, clusterEndpoint: string, clusterId: string, stage: string, subnetSelection: SubnetSelection, clusterAccessSecurityGroupId?: string) {
     new CfnOutput(scope, `ClusterEndpointExport-${stage}-${clusterId}`, {
         exportName: `ClusterEndpoint-${stage}-${clusterId}`,
         value: clusterEndpoint,
         description: 'The endpoint URL of the cluster',
     });
+    if (subnetSelection.subnets) {
+        const subnetIds = subnetSelection.subnets.map(s => s.subnetId);
+        new CfnOutput(scope, `ClusterSubnets-${stage}-${clusterId}`, {
+            exportName: `ClusterSubnets-${stage}-${clusterId}`,
+            value: subnetIds.join(","),
+            description: 'The subnet ids of the deployed cluster',
+        });
+    }
     if (clusterAccessSecurityGroupId) {
         new CfnOutput(scope, `ClusterAccessSecurityGroupIdExport-${stage}-${clusterId}`, {
             exportName: `ClusterAccessSecurityGroupId-${stage}-${clusterId}`,

--- a/lib/opensearch-domain-stack.ts
+++ b/lib/opensearch-domain-stack.ts
@@ -204,7 +204,7 @@ export class OpenSearchDomainStack extends Stack {
       zoneAwareness: zoneAwarenessConfig,
       removalPolicy: props.domainRemovalPolicy
     });
-    generateClusterExports(this, domain.domainEndpoint, props.clusterId, props.stage, props.vpcDetails.clusterAccessSecurityGroup?.securityGroupId)
+    generateClusterExports(this, domain.domainEndpoint, props.clusterId, props.stage, props.vpcDetails.subnetSelection, props.vpcDetails.clusterAccessSecurityGroup?.securityGroupId)
   }
 }
 


### PR DESCRIPTION
### Description
Add cluster export for subnet ids in Cloudformation

### Issues Resolved
N/A

### Testing
Cloud testing

### Check List
- [ ] New functionality includes testing
- [ ] Documentation of feature or new context options are documented

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
