### PR TITLE
feat: support public (no-VPC) managed domains via publicAccess option

### DIFF
--- a/lib/components/cluster-config.ts
+++ b/lib/components/cluster-config.ts
@@ -88,6 +88,8 @@ export interface ManagedClusterConfig extends BaseClusterConfig {
     autoTuneEnabled?: boolean;
     /** Allow all traffic from the VPC CIDR to the cluster */
     allowAllVpcTraffic?: boolean;
+    /** Deploy as a public (internet-facing) domain without VPC placement */
+    publicAccess?: boolean;
 }
 
 /** A single collection within a serverless collection group */

--- a/lib/components/context-parsing.ts
+++ b/lib/components/context-parsing.ts
@@ -135,7 +135,7 @@ export function parseClusterConfig(config: Record<string, any>, defaults: Record
         'samlRolesKey', 'samlSubjectKey', 'samlSessionTimeoutMinutes',
         'cognitoUserPoolId', 'cognitoIdentityPoolId', 'cognitoRoleArn',
         'customEndpoint', 'customEndpointCertificateArn',
-        'autoTuneEnabled', 'allowAllVpcTraffic',
+        'autoTuneEnabled', 'allowAllVpcTraffic', 'publicAccess',
     ];
     const serverlessOnlyFields = ['collectionType', 'standbyReplicas', 'sourceIPAddresses'];
 
@@ -234,6 +234,7 @@ export function parseClusterConfig(config: Record<string, any>, defaults: Record
         customEndpointCertificateArn: getContextForType('customEndpointCertificateArn', 'string', defaults, config),
         autoTuneEnabled: getContextForType('autoTuneEnabled', 'boolean', defaults, config),
         allowAllVpcTraffic: getContextForType('allowAllVpcTraffic', 'boolean', defaults, config),
+        publicAccess: getContextForType('publicAccess', 'boolean', defaults, config),
         slowSearchLogEnabled: getContextForType('slowSearchLogEnabled', 'boolean', defaults, config),
         slowSearchLogGroupARN: getContextForType('slowSearchLogGroupARN', 'string', defaults, config),
         auditLogEnabled: getContextForType('auditLogEnabled', 'boolean', defaults, config),

--- a/lib/components/managed-domain.ts
+++ b/lib/components/managed-domain.ts
@@ -20,11 +20,11 @@ import {ManagedClusterConfig} from "./cluster-config";
  * This is a helper function, not a separate stack — all resources
  * are created in the caller's stack scope.
  */
-export function createManagedDomain(stack: Stack, config: ManagedClusterConfig, stage: string, vpcDetails: VpcDetails): void {
+export function createManagedDomain(stack: Stack, config: ManagedClusterConfig, stage: string, vpcDetails?: VpcDetails): void {
     const prefix = config.clusterId;
 
     // Skip for first synthesis stage (dummy VPC from lookup)
-    if (vpcDetails.vpc.vpcId === "vpc-12345") {
+    if (vpcDetails?.vpc.vpcId === "vpc-12345") {
         return;
     }
 
@@ -56,21 +56,26 @@ export function createManagedDomain(stack: Stack, config: ManagedClusterConfig, 
         });
     }
 
-    const numSubnets = vpcDetails.subnetSelection.subnets;
-    if (!numSubnets || numSubnets.length < 1) {
-        throw new Error("Internal error: There should always be at least 1 subnet in the VpcDetails subnet selection");
-    }
-    const numAZs = numSubnets.length;
-    validateNodeCounts(numAZs, config);
-    const zoneAwarenessConfig: ZoneAwarenessConfig | undefined = numAZs > 1
-        ? {enabled: true, availabilityZoneCount: numAZs} : undefined;
-
-    const domainSubnets: SubnetSelection[] = [vpcDetails.subnetSelection];
-
+    let zoneAwarenessConfig: ZoneAwarenessConfig | undefined;
+    let domainSubnets: SubnetSelection[] | undefined;
+    let numAZs: number | undefined;
     const securityGroups: ISecurityGroup[] = [];
-    if (vpcDetails.clusterAccessSecurityGroup) {
-        securityGroups.push(vpcDetails.clusterAccessSecurityGroup);
+
+    if (vpcDetails) {
+        const numSubnets = vpcDetails.subnetSelection.subnets;
+        if (!numSubnets || numSubnets.length < 1) {
+            throw new Error("Internal error: There should always be at least 1 subnet in the VpcDetails subnet selection");
+        }
+        numAZs = numSubnets.length;
+        validateNodeCounts(numAZs, config);
+        zoneAwarenessConfig = numAZs > 1
+            ? {enabled: true, availabilityZoneCount: numAZs} : undefined;
+        domainSubnets = [vpcDetails.subnetSelection];
+        if (vpcDetails.clusterAccessSecurityGroup) {
+            securityGroups.push(vpcDetails.clusterAccessSecurityGroup);
+        }
     }
+
     if (config.clusterSecurityGroupIds) {
         for (let i = 0; i < config.clusterSecurityGroupIds.length; i++) {
             securityGroups.push(SecurityGroup.fromLookupById(stack, `${prefix}-domainSecurityGroup-${i}`, config.clusterSecurityGroupIds[i]));
@@ -152,9 +157,9 @@ export function createManagedDomain(stack: Stack, config: ManagedClusterConfig, 
             auditLogEnabled: config.auditLogEnabled,
             auditLogGroup: auditLG,
         },
-        vpc: vpcDetails.vpc,
+        vpc: vpcDetails?.vpc,
         vpcSubnets: domainSubnets,
-        securityGroups,
+        securityGroups: securityGroups.length > 0 ? securityGroups : undefined,
         zoneAwareness: zoneAwarenessConfig,
         coldStorageEnabled: config.coldStorageEnabled,
         offPeakWindowEnabled: config.offPeakWindowEnabled,
@@ -199,7 +204,7 @@ export function createManagedDomain(stack: Stack, config: ManagedClusterConfig, 
         {id: 'AwsSolutions-OS9', reason: 'Log publishing is user-configurable via loggingAppLogEnabled, slowSearchLogEnabled, and auditLogEnabled context options'},
     ]);
 
-    generateClusterExports(stack, domain, config.clusterId, stage, vpcDetails.subnetSelection, vpcDetails.clusterAccessSecurityGroup?.securityGroupId);
+    generateClusterExports(stack, domain, config.clusterId, stage, vpcDetails?.subnetSelection, vpcDetails?.clusterAccessSecurityGroup?.securityGroupId);
 }
 
 function getEbsVolumeType(ebsVolumeTypeName: string): EbsDeviceVolumeType | undefined {
@@ -239,7 +244,7 @@ function validateNodeCounts(numAZs: number, config: ManagedClusterConfig) {
     }
 }
 
-function generateClusterExports(stack: Stack, domain: Domain, clusterId: string, stage: string, subnetSelection: SubnetSelection, clusterAccessSecurityGroupId?: string) {
+function generateClusterExports(stack: Stack, domain: Domain, clusterId: string, stage: string, subnetSelection?: SubnetSelection, clusterAccessSecurityGroupId?: string) {
     new CfnOutput(stack, `ClusterEndpointExport-${stage}-${clusterId}`, {
         exportName: `ClusterEndpoint-${stage}-${clusterId}`,
         value: domain.domainEndpoint,
@@ -258,7 +263,7 @@ function generateClusterExports(stack: Stack, domain: Domain, clusterId: string,
         description: 'The ARN of the OpenSearch domain',
     });
 
-    if (subnetSelection.subnets) {
+    if (subnetSelection?.subnets) {
         const subnetIds = subnetSelection.subnets.map(s => s.subnetId);
         new CfnOutput(stack, `ClusterSubnets-${stage}-${clusterId}`, {
             exportName: `ClusterSubnets-${stage}-${clusterId}`,

--- a/lib/opensearch-stack.ts
+++ b/lib/opensearch-stack.ts
@@ -29,16 +29,16 @@ export class OpenSearchStack extends Stack {
         super(scope, id, props);
 
         const {stage, managedClusters, serverlessClusters} = props;
-        const hasManagedClusters = managedClusters.length > 0;
+        const hasVpcManagedClusters = managedClusters.some(c => !c.publicAccess);
         const serverlessNeedsVpc = serverlessClusters.some(c => c.createVpcEndpoint);
 
         // --- VPC (when managed clusters need it or serverless needs a VPC endpoint) ---
         let vpcDetails: VpcDetails | undefined;
-        if (hasManagedClusters || serverlessNeedsVpc) {
+        if (hasVpcManagedClusters || serverlessNeedsVpc) {
             if (props.vpcId) {
-                const clusterId = hasManagedClusters ? managedClusters[0].clusterId : serverlessClusters[0].clusterId;
-                const subnetIds = hasManagedClusters ? managedClusters[0].clusterSubnetIds : undefined;
-                const allowAllVpcTraffic = managedClusters.some(c => c.allowAllVpcTraffic);
+                const clusterId = hasVpcManagedClusters ? managedClusters.filter(c => !c.publicAccess)[0].clusterId : serverlessClusters[0].clusterId;
+                const subnetIds = hasVpcManagedClusters ? managedClusters.filter(c => !c.publicAccess)[0].clusterSubnetIds : undefined;
+                const allowAllVpcTraffic = managedClusters.some(c => !c.publicAccess && c.allowAllVpcTraffic);
                 let sg: SecurityGroup | undefined;
                 if (allowAllVpcTraffic) {
                     const importedVpc = Vpc.fromLookup(this, 'ImportedVpc', { vpcId: props.vpcId });
@@ -57,17 +57,17 @@ export class OpenSearchStack extends Stack {
                 }
                 vpcDetails = VpcDetails.fromVpcLookup(this, props.vpcId, clusterId, subnetIds, sg);
             } else {
-                const allowAllVpcTraffic = managedClusters.some(c => c.allowAllVpcTraffic);
+                const allowAllVpcTraffic = managedClusters.some(c => !c.publicAccess && c.allowAllVpcTraffic);
                 vpcDetails = this.createVpc(stage, props.vpcAZCount, props.vpcCidr, allowAllVpcTraffic, props.supportIpv6);
             }
         }
 
         // --- Managed domains ---
         for (const config of managedClusters) {
-            if (!vpcDetails) {
-                throw new Error("Internal error: VPC details should be resolved for managed clusters");
+            if (!config.publicAccess && !vpcDetails) {
+                throw new Error("Internal error: VPC details should be resolved for VPC-based managed clusters");
             }
-            createManagedDomain(this, config, stage, vpcDetails);
+            createManagedDomain(this, config, stage, config.publicAccess ? undefined : vpcDetails);
         }
 
         // --- Serverless collections ---


### PR DESCRIPTION
## Summary

Add a `publicAccess` boolean to `ManagedClusterConfig` that deploys managed OpenSearch domains as internet-facing (public) endpoints without VPC placement.

## Motivation

In CI/CD pipelines (e.g. the opensearch-migrations EKS integ tests), the current architecture forces a sequential dependency:

```
Deploy Clusters (CDK creates VPC + AOS domains) → Bootstrap MA (imports VPC for EKS)
              ~20-30 min                                    ~20-30 min
```

The bootstrap step **must wait** for the CDK deploy because it needs the VPC ID and subnet IDs. With public AOS domains, this dependency is eliminated:

```
┬─ Deploy Clusters (CDK, public AOS, no VPC)  ─┬
└─ Bootstrap MA (--deploy-create-vpc-cfn)       ┘
              ~20-30 min (PARALLEL)
```

This also eliminates the shared-VPC cleanup issues where DELETE_FAILED stacks pile up due to cross-stack ENI/subnet dependencies.

## Changes

- **cluster-config.ts**: Added `publicAccess?: boolean` to `ManagedClusterConfig`
- **context-parsing.ts**: Parse `publicAccess` field, added to `managedOnlyFields` validation
- **opensearch-stack.ts**: Only create/import VPC when at least one managed cluster does NOT have `publicAccess`
- **managed-domain.ts**: Made `vpcDetails` optional; skip VPC/subnet/SG configuration and AZ-based node count validation for public domains

## Testing

All 86 existing tests pass with no changes. Lint clean. Snapshots match.