### PR TITLE
ci: add merge_group trigger for merge queue compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions:
   contents: read
@@ -73,7 +74,7 @@ jobs:
 
   cfn-diff:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6


### PR DESCRIPTION
Adds the `merge_group` event trigger to CI.yml so that required checks run when PRs enter the merge queue.

## Changes
- Added `merge_group:` to the `on:` block in CI.yml
- Updated `cfn-diff` job condition to also run on `merge_group` events (it was previously gated to `pull_request` only)

Without this, the merge queue would fail because the required CI checks wouldn't trigger on merge group events.