### PR TITLE
fix: reject publicAccess + openAccessPolicyEnabled combination

### DIFF
--- a/lib/components/managed-domain.ts
+++ b/lib/components/managed-domain.ts
@@ -28,6 +28,14 @@ export function createManagedDomain(stack: Stack, config: ManagedClusterConfig, 
         return;
     }
 
+    if (config.publicAccess && config.openAccessPolicyEnabled) {
+        throw new Error(
+            `Cluster '${prefix}': 'publicAccess' and 'openAccessPolicyEnabled' cannot both be true. ` +
+            `Public domains require a restrictive access policy (e.g. account-scoped SigV4). ` +
+            `Use 'accessPolicies' with a scoped principal instead of 'openAccessPolicyEnabled'.`
+        );
+    }
+
     const version = config.clusterVersion
         ? getEngineVersion(config.clusterVersion)
         : getEngineVersion(LATEST_AOS_VERSION);


### PR DESCRIPTION
Public domains with `openAccessPolicyEnabled: true` create an `Allow *` access policy that AWS rejects with:

> Apply a restrictive access policy to your domain

This fails after ~12 minutes (domain creation completes, then the access policy custom resource fails, triggering a full rollback with another ~15 min domain deletion).

This PR fails immediately at CDK synth time with a clear error message guiding the user to use `accessPolicies` with a scoped principal instead.