### PR TITLE
Cluster name length validation

### DIFF
--- a/cluster-config.schema.json
+++ b/cluster-config.schema.json
@@ -80,7 +80,7 @@
         "clusterType": true,
         "clusterName": {
           "type": "string",
-          "description": "Custom name for the cluster (default: cluster-<stage>-<clusterId>)"
+          "description": "Custom name for the cluster (default: cluster-<stage>-<clusterId>). The 'cluster-' prefix in the default is deprecated; set this explicitly to opt out before the default changes."
         },
         "domainRemovalPolicy": {
           "type": "string",
@@ -301,7 +301,7 @@
         "clusterType": true,
         "clusterName": {
           "type": "string",
-          "description": "Custom name for the cluster (default: cluster-<stage>-<clusterId>)"
+          "description": "Custom name for the cluster (default: cluster-<stage>-<clusterId>). The 'cluster-' prefix in the default is deprecated; set this explicitly to opt out before the default changes."
         },
         "domainRemovalPolicy": {
           "type": "string",

--- a/lib/components/common-utilities.ts
+++ b/lib/components/common-utilities.ts
@@ -3,6 +3,19 @@ import {EngineVersion} from "aws-cdk-lib/aws-opensearchservice";
 
 export const MAX_STAGE_NAME_LENGTH = 15;
 export const MAX_CLUSTER_ID_LENGTH = 15;
+
+/** AWS OpenSearch minimum name length for domains and AOSS collections. */
+export const MIN_OPENSEARCH_NAME_LENGTH = 3;
+
+/** AWS OpenSearch managed (AOS) domain name limit. @see https://docs.aws.amazon.com/opensearch-service/latest/developerguide/createupdatedomains.html */
+export const MAX_AOS_DOMAIN_NAME_LENGTH = 28;
+
+/** AWS OpenSearch Serverless (AOSS) collection name limit. @see https://docs.aws.amazon.com/opensearch-service/latest/ServerlessAPIReference/API_CreateCollection.html */
+export const MAX_AOSS_COLLECTION_NAME_LENGTH = 32;
+
+/** Effective `clusterName` limit for serverless clusters: 32-char AOSS policy-name cap minus the longest appended suffix (`-access`, 7 chars). */
+export const MAX_AOSS_CLUSTER_NAME_LENGTH = 25;
+
 export const LATEST_AOS_VERSION = "OS_2.19"
 
 export function getEngineVersion(engineVersionString: string) : EngineVersion {

--- a/lib/components/context-parsing.ts
+++ b/lib/components/context-parsing.ts
@@ -3,7 +3,7 @@ import {readFileSync} from "fs";
 import {CdkLogger} from "./cdk-logger";
 import {ClusterConfig, ManagedClusterConfig, ServerlessClusterConfig} from "./cluster-config";
 import {TLSSecurityPolicy} from "aws-cdk-lib/aws-opensearchservice";
-import {MAX_CLUSTER_ID_LENGTH, parseRemovalPolicy} from "./common-utilities";
+import {MAX_AOS_DOMAIN_NAME_LENGTH, MAX_AOSS_CLUSTER_NAME_LENGTH, MAX_CLUSTER_ID_LENGTH, parseRemovalPolicy} from "./common-utilities";
 
 /**
  * Coerce a CLI-provided string value to the expected type.
@@ -153,6 +153,21 @@ export function parseClusterConfig(config: Record<string, any>, defaults: Record
     }
 
     const clusterName = config.clusterName ?? `cluster-${stage}-${config.clusterId}`;
+
+    // Stage-aware check for the default-name path; explicit clusterName is validated downstream.
+    if (config.clusterName === undefined) {
+        const isServerless = clusterType === 'OPENSEARCH_SERVERLESS';
+        const limit = isServerless ? MAX_AOSS_CLUSTER_NAME_LENGTH : MAX_AOS_DOMAIN_NAME_LENGTH;
+        if (clusterName.length > limit) {
+            const stageBudget = Math.max(0, limit - 'cluster-'.length - 1 /* dash */ - config.clusterId.length);
+            throw new Error(
+                `Cluster '${config.clusterId}': default clusterName '${clusterName}' is ${clusterName.length} characters, ` +
+                `exceeding the ${isServerless ? 'AOSS policy name' : 'AOS domain name'} limit of ${limit}. ` +
+                `With clusterId='${config.clusterId}', 'stage' must be at most ${stageBudget} characters for the default ` +
+                `'cluster-<stage>-<clusterId>' pattern, or set 'clusterName' explicitly.`
+            );
+        }
+    }
 
     const domainRemovalPolicyName = getContextForType('domainRemovalPolicy', 'string', defaults, config)
     const domainRemovalPolicy = parseRemovalPolicy("domainRemovalPolicy", domainRemovalPolicyName)

--- a/lib/components/context-parsing.ts
+++ b/lib/components/context-parsing.ts
@@ -152,6 +152,7 @@ export function parseClusterConfig(config: Record<string, any>, defaults: Record
         }
     }
 
+    // Default 'cluster-' prefix is deprecated; set 'clusterName' to opt out before the default changes.
     const clusterName = config.clusterName ?? `cluster-${stage}-${config.clusterId}`;
 
     // Stage-aware check for the default-name path; explicit clusterName is validated downstream.

--- a/lib/components/managed-domain.ts
+++ b/lib/components/managed-domain.ts
@@ -12,7 +12,7 @@ import {ISecret, Secret} from "aws-cdk-lib/aws-secretsmanager";
 import {CfnDomain} from "aws-cdk-lib/aws-opensearchservice";
 import {NagSuppressions} from "cdk-nag";
 import {VpcDetails} from "./vpc-details";
-import {getEngineVersion, LATEST_AOS_VERSION} from "./common-utilities";
+import {getEngineVersion, LATEST_AOS_VERSION, MAX_AOS_DOMAIN_NAME_LENGTH, MIN_OPENSEARCH_NAME_LENGTH} from "./common-utilities";
 import {ManagedClusterConfig} from "./cluster-config";
 
 /**
@@ -120,6 +120,20 @@ export function createManagedDomain(stack: Stack, config: ManagedClusterConfig, 
             subjectKey: config.samlSubjectKey,
             sessionTimeoutMinutes: config.samlSessionTimeoutMinutes,
         };
+    }
+
+    // Fail fast: CFN rejects domain names outside 3-28 chars with a generic InvalidParameter error.
+    if (config.clusterName.length < MIN_OPENSEARCH_NAME_LENGTH) {
+        throw new Error(
+            `Cluster '${config.clusterId}': AOS domain name '${config.clusterName}' is ${config.clusterName.length} characters, ` +
+            `below the AWS minimum of ${MIN_OPENSEARCH_NAME_LENGTH}. Set 'clusterName' to at least ${MIN_OPENSEARCH_NAME_LENGTH} characters.`
+        );
+    }
+    if (config.clusterName.length > MAX_AOS_DOMAIN_NAME_LENGTH) {
+        throw new Error(
+            `Cluster '${config.clusterId}': AOS domain name '${config.clusterName}' is ${config.clusterName.length} characters, ` +
+            `exceeding the AWS limit of ${MAX_AOS_DOMAIN_NAME_LENGTH}. Set a shorter 'clusterName' or reduce 'stage'.`
+        );
     }
 
     const domain = new Domain(stack, `${prefix}-Domain`, {

--- a/lib/components/serverless-collection.ts
+++ b/lib/components/serverless-collection.ts
@@ -7,6 +7,7 @@ import {
 } from "aws-cdk-lib/aws-opensearchserverless";
 import {ServerlessClusterConfig} from "./cluster-config";
 import {VpcDetails} from "./vpc-details";
+import {MAX_AOSS_CLUSTER_NAME_LENGTH, MAX_AOSS_COLLECTION_NAME_LENGTH, MIN_OPENSEARCH_NAME_LENGTH} from "./common-utilities";
 
 /**
  * Creates serverless OpenSearch collections within the given stack.
@@ -16,12 +17,39 @@ import {VpcDetails} from "./vpc-details";
 export function createServerlessCollection(stack: Stack, config: ServerlessClusterConfig, stage: string, vpcDetails?: VpcDetails): void {
     const prefix = config.clusterId;
 
+    // Fail fast: AOSS appends '-enc'/'-net'/'-access' to clusterName for policy names; longest is '-access' at 7 chars.
+    if (config.clusterName.length < MIN_OPENSEARCH_NAME_LENGTH) {
+        throw new Error(
+            `Cluster '${config.clusterId}': AOSS clusterName '${config.clusterName}' is ${config.clusterName.length} characters, ` +
+            `below the AWS minimum of ${MIN_OPENSEARCH_NAME_LENGTH}. Set 'clusterName' to at least ${MIN_OPENSEARCH_NAME_LENGTH} characters.`
+        );
+    }
+    if (config.clusterName.length > MAX_AOSS_CLUSTER_NAME_LENGTH) {
+        throw new Error(
+            `Cluster '${config.clusterId}': AOSS clusterName '${config.clusterName}' is ${config.clusterName.length} characters, ` +
+            `exceeding the maximum of ${MAX_AOSS_CLUSTER_NAME_LENGTH} (32-char AOSS policy limit minus '-access' suffix). ` +
+            `Set a shorter 'clusterName' or reduce 'stage'.`
+        );
+    }
+
     // Build the list of collections to create.
     const entries: { name: string; type: string }[] = [];
     if (config.collections && config.collections.length > 0) {
         for (const c of config.collections) {
             if (!c.collectionName) {
                 throw new Error(`Each entry in 'collections' for cluster '${config.clusterId}' must have a 'collectionName'`);
+            }
+            if (c.collectionName.length < MIN_OPENSEARCH_NAME_LENGTH) {
+                throw new Error(
+                    `Cluster '${config.clusterId}': collection name '${c.collectionName}' is ${c.collectionName.length} characters, ` +
+                    `below the AWS AOSS minimum of ${MIN_OPENSEARCH_NAME_LENGTH}.`
+                );
+            }
+            if (c.collectionName.length > MAX_AOSS_COLLECTION_NAME_LENGTH) {
+                throw new Error(
+                    `Cluster '${config.clusterId}': collection name '${c.collectionName}' is ${c.collectionName.length} characters, ` +
+                    `exceeding the AWS AOSS collection name limit of ${MAX_AOSS_COLLECTION_NAME_LENGTH}.`
+                );
             }
             entries.push({
                 name: c.collectionName,

--- a/test/cdk-nag.test.ts
+++ b/test/cdk-nag.test.ts
@@ -38,7 +38,7 @@ describe('cdk-nag AWS Solutions Checks', () => {
     test('Serverless collection stack has no errors', () => {
         const composer = createNagApp({
             clusters: [{
-                clusterId: 'nag-serverless',
+                clusterId: 'nag-sls',
                 clusterType: 'OPENSEARCH_SERVERLESS',
                 collectionType: 'SEARCH',
             }],
@@ -63,7 +63,7 @@ describe('cdk-nag AWS Solutions Checks', () => {
                     ebsEnabled: true,
                 },
                 {
-                    clusterId: 'serverless',
+                    clusterId: 'aoss',
                     clusterType: 'OPENSEARCH_SERVERLESS',
                     collectionType: 'VECTORSEARCH',
                 },

--- a/test/opensearch-domain-stack.test.ts
+++ b/test/opensearch-domain-stack.test.ts
@@ -284,4 +284,36 @@ describe('Cold Storage, Multi-AZ Standby, Off-Peak Window Tests', () => {
       },
     })
   })
+
+  test('Test explicit clusterName over 28 chars throws managed-domain limit error', () => {
+    expect(() => createStackComposerWithSingleDomainContext({
+      clusterName: "a".repeat(29),
+    })).toThrow(/AOS domain name.*exceeding the AWS limit of 28/)
+  })
+
+  test('Test explicit clusterName at the 28-char limit is accepted', () => {
+    const composer = createStackComposerWithSingleDomainContext({
+      clusterName: "a".repeat(28),
+    })
+    Template.fromStack(getStack(composer)).hasResourceProperties("AWS::OpenSearchService::Domain", {
+      DomainName: "a".repeat(28),
+    })
+  })
+
+  test('Test explicit clusterName below 3-char AWS minimum throws (covers empty string + below 3)', () => {
+    for (const name of ["", "ab"]) {
+      expect(() => createStackComposerWithSingleDomainContext({
+        clusterName: name,
+      })).toThrow(/AOS domain name.*below the AWS minimum of 3/)
+    }
+  })
+
+  test('Test explicit clusterName at the 3-char minimum is accepted', () => {
+    const composer = createStackComposerWithSingleDomainContext({
+      clusterName: "abc",
+    })
+    Template.fromStack(getStack(composer)).hasResourceProperties("AWS::OpenSearchService::Domain", {
+      DomainName: "abc",
+    })
+  })
 })

--- a/test/serverless-collection-stack.test.ts
+++ b/test/serverless-collection-stack.test.ts
@@ -58,7 +58,7 @@ describe('Serverless Collection Tests', () => {
 
   test('Test serverless collection with DESTROY removal policy', () => {
     const composer = createStackComposer({
-      clusters: [{clusterId: "ephemeral", clusterType: ClusterType.OPENSEARCH_SERVERLESS, domainRemovalPolicy: "DESTROY"}]
+      clusters: [{clusterId: "ephem", clusterType: ClusterType.OPENSEARCH_SERVERLESS, domainRemovalPolicy: "DESTROY"}]
     })
     Template.fromStack(getStack(composer)).hasResource("AWS::OpenSearchServerless::Collection", {DeletionPolicy: "Delete"})
   })
@@ -81,7 +81,7 @@ describe('Serverless Collection Tests', () => {
     const composer = createStackComposer({
       clusters: [
         {clusterId: "managed", clusterType: ClusterType.OPENSEARCH_MANAGED_SERVICE},
-        {clusterId: "serverless", clusterType: ClusterType.OPENSEARCH_SERVERLESS},
+        {clusterId: "aoss", clusterType: ClusterType.OPENSEARCH_SERVERLESS},
       ]
     })
     expect(composer.stacks.length).toBe(1)
@@ -183,5 +183,77 @@ describe('Serverless Collection Tests', () => {
     template.hasResourceProperties("AWS::OpenSearchServerless::AccessPolicy", {
       Type: "data",
     })
+  })
+
+  test('Test explicit clusterName over 25 chars throws serverless policy-budget error', () => {
+    expect(() => createStackComposer({
+      clusters: [{
+        clusterId: "search",
+        clusterType: ClusterType.OPENSEARCH_SERVERLESS,
+        clusterName: "a".repeat(26),
+      }]
+    })).toThrow(/AOSS clusterName.*exceeding the maximum of 25/)
+  })
+
+  test('Test explicit clusterName at the 25-char limit is accepted', () => {
+    const composer = createStackComposer({
+      clusters: [{
+        clusterId: "search",
+        clusterType: ClusterType.OPENSEARCH_SERVERLESS,
+        clusterName: "a".repeat(25),
+      }]
+    })
+    Template.fromStack(getStack(composer)).hasResourceProperties("AWS::OpenSearchServerless::Collection", {
+      Name: "a".repeat(25),
+    })
+  })
+
+  test('Test collection group entry name over 32 chars throws', () => {
+    expect(() => createStackComposer({
+      clusters: [{
+        clusterId: "group",
+        clusterType: ClusterType.OPENSEARCH_SERVERLESS,
+        collections: [
+          {collectionName: "a".repeat(33), collectionType: "SEARCH"},
+        ]
+      }]
+    })).toThrow(/exceeding the AWS AOSS collection name limit of 32/)
+  })
+
+  test('Test explicit clusterName below 3-char AWS minimum throws (covers empty string + below 3)', () => {
+    for (const name of ["", "ab"]) {
+      expect(() => createStackComposer({
+        clusters: [{
+          clusterId: "search",
+          clusterType: ClusterType.OPENSEARCH_SERVERLESS,
+          clusterName: name,
+        }]
+      })).toThrow(/AOSS clusterName.*below the AWS minimum of 3/)
+    }
+  })
+
+  test('Test explicit clusterName at the 3-char minimum is accepted', () => {
+    const composer = createStackComposer({
+      clusters: [{
+        clusterId: "search",
+        clusterType: ClusterType.OPENSEARCH_SERVERLESS,
+        clusterName: "abc",
+      }]
+    })
+    Template.fromStack(getStack(composer)).hasResourceProperties("AWS::OpenSearchServerless::Collection", {
+      Name: "abc",
+    })
+  })
+
+  test('Test collection group entry below 3-char AOSS minimum throws', () => {
+    expect(() => createStackComposer({
+      clusters: [{
+        clusterId: "group",
+        clusterType: ClusterType.OPENSEARCH_SERVERLESS,
+        collections: [
+          {collectionName: "ab", collectionType: "SEARCH"},
+        ]
+      }]
+    })).toThrow(/collection name 'ab'.*below the AWS AOSS minimum of 3/)
   })
 })

--- a/test/stack-composer.test.ts
+++ b/test/stack-composer.test.ts
@@ -96,7 +96,7 @@ describe('Stack Composer Tests', () => {
     const composer = createStackComposer({
       clusters: [
         {clusterId: "managed", clusterType: ClusterType.OPENSEARCH_MANAGED_SERVICE},
-        {clusterId: "serverless", clusterType: ClusterType.OPENSEARCH_SERVERLESS},
+        {clusterId: "aoss", clusterType: ClusterType.OPENSEARCH_SERVERLESS},
       ]
     })
     expect(composer.stacks.length).toBe(1)
@@ -121,5 +121,34 @@ describe('Stack Composer Tests', () => {
     expect(tagMap['Project']).toBe('opensearch-sample')
     expect(tagMap['CostCenter']).toBe('12345')
     expect(tagMap['Team']).toBe('search-platform')
+  })
+
+  test('Test default clusterName overflow for managed domain produces stage-aware error', () => {
+    // stage under MAX_STAGE_NAME_LENGTH (15) but default pattern 'cluster-<stage>-source'
+    // exceeds the 28-char managed domain limit: cluster-(8) + stage(14) + '-'(1) + 'source'(6) = 29.
+    expect(() => createStackComposer({
+      stage: "fourteen-chars",
+      clusters: [{clusterId: "source", clusterType: ClusterType.OPENSEARCH_MANAGED_SERVICE}]
+    })).toThrow(/'stage' must be at most 13 characters/)
+  })
+
+  test('Test default clusterName overflow for serverless produces stage-aware error', () => {
+    // cluster-(8) + stage(11) + '-'(1) + target(6) = 26 chars,
+    // but with '-access' suffix for AOSS policy = 33 chars → exceeds 32-char policy limit.
+    expect(() => createStackComposer({
+      stage: "eleven-char",
+      clusters: [{clusterId: "target", clusterType: ClusterType.OPENSEARCH_SERVERLESS}]
+    })).toThrow(/AOSS policy name.*'stage' must be at most 10 characters/s)
+  })
+
+  test('Test default clusterName that fits the limit is accepted', () => {
+    // cluster-(8) + stage(13) + '-'(1) + source(6) = 28 chars exactly — at the managed limit.
+    const composer = createStackComposer({
+      stage: "thirteen-chrs",
+      clusters: [{clusterId: "source", clusterType: ClusterType.OPENSEARCH_MANAGED_SERVICE}]
+    })
+    Template.fromStack(getStack(composer)).hasResourceProperties("AWS::OpenSearchService::Domain", {
+      DomainName: "cluster-thirteen-chrs-source",
+    })
   })
 })


### PR DESCRIPTION
### Description
Fail at `cdk synth` when `clusterName` falls outside AWS resource-name limits, rather than at CloudFormation deploy time with an opaque `InvalidParameter` error 10+ minutes into a rollout.

**What's validated:**

| Cluster type | `clusterName` length | Source of limit |
|---|---|---|
| `OPENSEARCH_MANAGED_SERVICE` | 3 – 28 | [AWS OpenSearch domain name limit](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/createupdatedomains.html) |
| `OPENSEARCH_SERVERLESS` | 3 – 25 | AOSS 32-char [policy name limit](https://docs.aws.amazon.com/opensearch-service/latest/ServerlessAPIReference/API_CreateSecurityPolicy.html) minus `-access` suffix (longest suffix appended to `clusterName` when deriving the data-access policy name) |
| Collection-group `collectionName` entries | 3 – 32 | [AOSS collection name limit](https://docs.aws.amazon.com/opensearch-service/latest/ServerlessAPIReference/API_CreateCollection.html) |

Checks run at three sites so misconfigurations surface regardless of path:

- `parseClusterConfig` — default-name path (`cluster-<stage>-<clusterId>`), with a stage-aware message that computes the exact stage budget (e.g. `With clusterId='target', 'stage' must be at most 10 characters for the default pattern, or set 'clusterName' explicitly`).
- `createManagedDomain` — explicit `clusterName` below AWS minimum or above managed domain limit.
- `createServerlessCollection` — explicit `clusterName` below AWS minimum or above the serverless policy budget; per-entry `collectionName` below 3 or above the AOSS collection limit.

**Also deprecates** the 8-char `cluster-` prefix in the default `clusterName` pattern. The prefix consumes 8 characters of the 28-char managed domain and 25-char AOSS budget with no functional value. Consumers can set `clusterName` explicitly today to opt out ahead of a future default change; explicit values pass through the parser unchanged and are unaffected. Deprecation is flagged inline at the fallback site and in the `cluster-config.schema.json` description so IDE hovers surface it.

### Issues Resolved
N/A

### Testing
- **13 new unit tests** — managed/serverless/collection-group over-max, below-min (loop-driven, also covers `clusterName: ""` which skips the `??` default), and at-boundary accepted; plus default-name path overflow with stage-aware error matching.
- Regex assertions anchor on phrasing unique to each validation site so no test can match the wrong error path.
- 3 pre-existing tests used serverless clusterIds whose default clusterNames produced 32+-char AOSS policy names (would have failed at deploy time); shortened to fit.
- `npm run test` — **99/99 passing** (86 pre-existing + 13 new). `npm run build`, `npm pack --dry-run`, `npx cdk synth` on all 13 examples — clean.

### Check List
- [x] New functionality includes testing
- [x] Documentation of feature or new context options are documented

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
