### PR TITLE
Feat: drop 'cluster-' prefix from default clusterName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 | Series | Theme | Key Highlights |
 |--------|-------|---------------|
+| **0.4.x** | Naming cleanup | Dropped `cluster-` prefix from default `clusterName` |
 | **0.3.x** | Single-stack simplification | 4 stacks → 1 `OpenSearchStack`, removed monitoring + VPC Lambda, discriminated JSON Schema, collection groups, SAML auth, cold storage, deploy script |
+
+## [0.4.0] - 2026-05-07
+
+### Breaking Changes
+
+- **Default `clusterName` pattern changed** from `cluster-<stage>-<clusterId>` to `<stage>-<clusterId>`. The `cluster-` prefix is removed. This was [deprecated in 0.3.11](https://github.com/aws-samples/amazon-opensearch-service-sample-cdk/pull/137) with a migration path; it is now the default. Any caller that did not set `clusterName` explicitly in their context will see their managed domain name, AOSS collection name, and AOSS policy names shorten by 8 characters.
+
+  **Migration:**
+  - **No action required** if you set `clusterName` explicitly in your context — explicit values have always passed through unchanged and are not affected by this change.
+  - **Action required** if you relied on the default and have external references (IAM policies, CloudWatch dashboards, Terraform imports, runbooks) that reference the literal `cluster-<stage>-<clusterId>` resource names: either set `clusterName` explicitly to preserve the old value, or update the external references to the new `<stage>-<clusterId>` form. Only the AWS-visible resource names change; CFN logical IDs and stack outputs are unaffected.
+  - **Example:**
+    - Old (0.3.x default): `stage="dev"` + `clusterId="search"` → domain name `cluster-dev-search`
+    - New (0.4.0 default): `stage="dev"` + `clusterId="search"` → domain name `dev-search`
+    - To keep the old name: set `"clusterName": "cluster-dev-search"` explicitly in your context.
+
+### Changed
+
+- Stage-budget math in the default-name validation error now reflects the shorter pattern. For a given `clusterId`, the maximum `stage` length is `limit - 1 - clusterId.length` (was `limit - 8 - 1 - clusterId.length`).
 
 ## [0.3.8] - 2026-03-27
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ A single CloudFormation stack `OpenSearch-prod-<region>` containing:
 |--------|------|:--------:|-------------|
 | `clusterId` | string | ✅ | Unique identifier (max 15 chars). |
 | `clusterType` | string | ✅ | `OPENSEARCH_MANAGED_SERVICE` or `OPENSEARCH_SERVERLESS` |
-| `clusterName` | string | — | Custom domain name. Default: `cluster-<stage>-<clusterId>` |
+| `clusterName` | string | — | Custom domain name. Default: `<stage>-<clusterId>` |
 | `domainRemovalPolicy` | string | — | `RETAIN` (default) or `DESTROY` |
 
 ### Managed Domain Options

--- a/cluster-config.schema.json
+++ b/cluster-config.schema.json
@@ -80,7 +80,7 @@
         "clusterType": true,
         "clusterName": {
           "type": "string",
-          "description": "Custom name for the cluster (default: cluster-<stage>-<clusterId>). The 'cluster-' prefix in the default is deprecated; set this explicitly to opt out before the default changes."
+          "description": "Custom name for the cluster (default: <stage>-<clusterId>)"
         },
         "domainRemovalPolicy": {
           "type": "string",
@@ -301,7 +301,7 @@
         "clusterType": true,
         "clusterName": {
           "type": "string",
-          "description": "Custom name for the cluster (default: cluster-<stage>-<clusterId>). The 'cluster-' prefix in the default is deprecated; set this explicitly to opt out before the default changes."
+          "description": "Custom name for the cluster (default: <stage>-<clusterId>)"
         },
         "domainRemovalPolicy": {
           "type": "string",

--- a/lib/components/context-parsing.ts
+++ b/lib/components/context-parsing.ts
@@ -152,20 +152,19 @@ export function parseClusterConfig(config: Record<string, any>, defaults: Record
         }
     }
 
-    // Default 'cluster-' prefix is deprecated; set 'clusterName' to opt out before the default changes.
-    const clusterName = config.clusterName ?? `cluster-${stage}-${config.clusterId}`;
+    const clusterName = config.clusterName ?? `${stage}-${config.clusterId}`;
 
     // Stage-aware check for the default-name path; explicit clusterName is validated downstream.
     if (config.clusterName === undefined) {
         const isServerless = clusterType === 'OPENSEARCH_SERVERLESS';
         const limit = isServerless ? MAX_AOSS_CLUSTER_NAME_LENGTH : MAX_AOS_DOMAIN_NAME_LENGTH;
         if (clusterName.length > limit) {
-            const stageBudget = Math.max(0, limit - 'cluster-'.length - 1 /* dash */ - config.clusterId.length);
+            const stageBudget = Math.max(0, limit - 1 /* dash */ - config.clusterId.length);
             throw new Error(
                 `Cluster '${config.clusterId}': default clusterName '${clusterName}' is ${clusterName.length} characters, ` +
                 `exceeding the ${isServerless ? 'AOSS policy name' : 'AOS domain name'} limit of ${limit}. ` +
                 `With clusterId='${config.clusterId}', 'stage' must be at most ${stageBudget} characters for the default ` +
-                `'cluster-<stage>-<clusterId>' pattern, or set 'clusterName' explicitly.`
+                `'<stage>-<clusterId>' pattern, or set 'clusterName' explicitly.`
             );
         }
     }

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -1093,7 +1093,7 @@ exports[`Snapshot Tests > Managed domain stack template snapshot 1`] = `
           "EnforceHTTPS": true,
           "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07",
         },
-        "DomainName": "cluster-unit-test-snap",
+        "DomainName": "unit-test-snap",
         "EBSOptions": {
           "EBSEnabled": true,
           "VolumeSize": 100,
@@ -1223,7 +1223,7 @@ exports[`Snapshot Tests > Mixed managed + serverless stack template snapshot 1`]
       },
     },
     "CollectionArnExportunittestsearch": {
-      "Description": "The ARN of the cluster-unit-test-search serverless collection",
+      "Description": "The ARN of the unit-test-search serverless collection",
       "Export": {
         "Name": "CollectionArn-unit-test-search",
       },
@@ -1235,7 +1235,7 @@ exports[`Snapshot Tests > Mixed managed + serverless stack template snapshot 1`]
       },
     },
     "CollectionEndpointExportunittestsearch": {
-      "Description": "The endpoint URL of the cluster-unit-test-search serverless collection",
+      "Description": "The endpoint URL of the unit-test-search serverless collection",
       "Export": {
         "Name": "CollectionEndpoint-unit-test-search",
       },
@@ -2291,7 +2291,7 @@ exports[`Snapshot Tests > Mixed managed + serverless stack template snapshot 1`]
           "EnforceHTTPS": true,
           "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07",
         },
-        "DomainName": "cluster-unit-test-domain",
+        "DomainName": "unit-test-domain",
         "EBSOptions": {
           "EBSEnabled": true,
           "VolumeSize": 100,
@@ -2347,7 +2347,7 @@ exports[`Snapshot Tests > Mixed managed + serverless stack template snapshot 1`]
         "searchNetworkPolicy",
       ],
       "Properties": {
-        "Name": "cluster-unit-test-search",
+        "Name": "unit-test-search",
         "StandbyReplicas": "DISABLED",
         "Tags": [
           {
@@ -2369,12 +2369,12 @@ exports[`Snapshot Tests > Mixed managed + serverless stack template snapshot 1`]
     },
     "searchDataAccessPolicy": {
       "Properties": {
-        "Name": "cluster-unit-test-search-access",
+        "Name": "unit-test-search-access",
         "Policy": {
           "Fn::Join": [
             "",
             [
-              "[{"Rules":[{"ResourceType":"collection","Resource":["collection/cluster-unit-test-search"],"Permission":["aoss:CreateCollectionItems","aoss:DeleteCollectionItems","aoss:UpdateCollectionItems","aoss:DescribeCollectionItems"]},{"ResourceType":"index","Resource":["index/cluster-unit-test-search/*"],"Permission":["aoss:CreateIndex","aoss:DeleteIndex","aoss:UpdateIndex","aoss:DescribeIndex","aoss:ReadDocument","aoss:WriteDocument"]}],"Principal":["arn:",
+              "[{"Rules":[{"ResourceType":"collection","Resource":["collection/unit-test-search"],"Permission":["aoss:CreateCollectionItems","aoss:DeleteCollectionItems","aoss:UpdateCollectionItems","aoss:DescribeCollectionItems"]},{"ResourceType":"index","Resource":["index/unit-test-search/*"],"Permission":["aoss:CreateIndex","aoss:DeleteIndex","aoss:UpdateIndex","aoss:DescribeIndex","aoss:ReadDocument","aoss:WriteDocument"]}],"Principal":["arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2388,16 +2388,16 @@ exports[`Snapshot Tests > Mixed managed + serverless stack template snapshot 1`]
     },
     "searchEncryptionPolicy": {
       "Properties": {
-        "Name": "cluster-unit-test-search-enc",
-        "Policy": "{"Rules":[{"ResourceType":"collection","Resource":["collection/cluster-unit-test-search"]}],"AWSOwnedKey":true}",
+        "Name": "unit-test-search-enc",
+        "Policy": "{"Rules":[{"ResourceType":"collection","Resource":["collection/unit-test-search"]}],"AWSOwnedKey":true}",
         "Type": "encryption",
       },
       "Type": "AWS::OpenSearchServerless::SecurityPolicy",
     },
     "searchNetworkPolicy": {
       "Properties": {
-        "Name": "cluster-unit-test-search-net",
-        "Policy": "[{"Rules":[{"ResourceType":"collection","Resource":["collection/cluster-unit-test-search"]},{"ResourceType":"dashboard","Resource":["collection/cluster-unit-test-search"]}],"AllowFromPublic":true}]",
+        "Name": "unit-test-search-net",
+        "Policy": "[{"Rules":[{"ResourceType":"collection","Resource":["collection/unit-test-search"]},{"ResourceType":"dashboard","Resource":["collection/unit-test-search"]}],"AllowFromPublic":true}]",
         "Type": "network",
       },
       "Type": "AWS::OpenSearchServerless::SecurityPolicy",
@@ -2438,7 +2438,7 @@ exports[`Snapshot Tests > Serverless collection stack template snapshot 1`] = `
   "Description": "OpenSearch Service infrastructure - managed domains, serverless collections, and networking",
   "Outputs": {
     "CollectionArnExportunittestsnap": {
-      "Description": "The ARN of the cluster-unit-test-snap serverless collection",
+      "Description": "The ARN of the unit-test-snap serverless collection",
       "Export": {
         "Name": "CollectionArn-unit-test-snap",
       },
@@ -2450,7 +2450,7 @@ exports[`Snapshot Tests > Serverless collection stack template snapshot 1`] = `
       },
     },
     "CollectionEndpointExportunittestsnap": {
-      "Description": "The endpoint URL of the cluster-unit-test-snap serverless collection",
+      "Description": "The endpoint URL of the unit-test-snap serverless collection",
       "Export": {
         "Name": "CollectionEndpoint-unit-test-snap",
       },
@@ -2477,7 +2477,7 @@ exports[`Snapshot Tests > Serverless collection stack template snapshot 1`] = `
         "snapNetworkPolicy",
       ],
       "Properties": {
-        "Name": "cluster-unit-test-snap",
+        "Name": "unit-test-snap",
         "StandbyReplicas": "DISABLED",
         "Tags": [
           {
@@ -2500,12 +2500,12 @@ exports[`Snapshot Tests > Serverless collection stack template snapshot 1`] = `
     },
     "snapDataAccessPolicy": {
       "Properties": {
-        "Name": "cluster-unit-test-snap-access",
+        "Name": "unit-test-snap-access",
         "Policy": {
           "Fn::Join": [
             "",
             [
-              "[{"Rules":[{"ResourceType":"collection","Resource":["collection/cluster-unit-test-snap"],"Permission":["aoss:CreateCollectionItems","aoss:DeleteCollectionItems","aoss:UpdateCollectionItems","aoss:DescribeCollectionItems"]},{"ResourceType":"index","Resource":["index/cluster-unit-test-snap/*"],"Permission":["aoss:CreateIndex","aoss:DeleteIndex","aoss:UpdateIndex","aoss:DescribeIndex","aoss:ReadDocument","aoss:WriteDocument"]}],"Principal":["arn:",
+              "[{"Rules":[{"ResourceType":"collection","Resource":["collection/unit-test-snap"],"Permission":["aoss:CreateCollectionItems","aoss:DeleteCollectionItems","aoss:UpdateCollectionItems","aoss:DescribeCollectionItems"]},{"ResourceType":"index","Resource":["index/unit-test-snap/*"],"Permission":["aoss:CreateIndex","aoss:DeleteIndex","aoss:UpdateIndex","aoss:DescribeIndex","aoss:ReadDocument","aoss:WriteDocument"]}],"Principal":["arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2519,16 +2519,16 @@ exports[`Snapshot Tests > Serverless collection stack template snapshot 1`] = `
     },
     "snapEncryptionPolicy": {
       "Properties": {
-        "Name": "cluster-unit-test-snap-enc",
-        "Policy": "{"Rules":[{"ResourceType":"collection","Resource":["collection/cluster-unit-test-snap"]}],"AWSOwnedKey":true}",
+        "Name": "unit-test-snap-enc",
+        "Policy": "{"Rules":[{"ResourceType":"collection","Resource":["collection/unit-test-snap"]}],"AWSOwnedKey":true}",
         "Type": "encryption",
       },
       "Type": "AWS::OpenSearchServerless::SecurityPolicy",
     },
     "snapNetworkPolicy": {
       "Properties": {
-        "Name": "cluster-unit-test-snap-net",
-        "Policy": "[{"Rules":[{"ResourceType":"collection","Resource":["collection/cluster-unit-test-snap"]},{"ResourceType":"dashboard","Resource":["collection/cluster-unit-test-snap"]}],"AllowFromPublic":true}]",
+        "Name": "unit-test-snap-net",
+        "Policy": "[{"Rules":[{"ResourceType":"collection","Resource":["collection/unit-test-snap"]},{"ResourceType":"dashboard","Resource":["collection/unit-test-snap"]}],"AllowFromPublic":true}]",
         "Type": "network",
       },
       "Type": "AWS::OpenSearchServerless::SecurityPolicy",

--- a/test/opensearch-domain-stack.test.ts
+++ b/test/opensearch-domain-stack.test.ts
@@ -181,7 +181,7 @@ function assertPrimaryDomainTemplate(template: Template) {
   template.resourceCountIs("AWS::OpenSearchService::Domain", 1)
   template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     EngineVersion: "OpenSearch_2.3",
-    DomainName: "cluster-unittest-dev-search",
+    DomainName: "unittest-dev-search",
     AdvancedSecurityOptions: {
       Enabled: true,
       MasterUserOptions: {MasterUserARN: "arn:aws:iam::12345678912:user/test-user"}

--- a/test/serverless-collection-stack.test.ts
+++ b/test/serverless-collection-stack.test.ts
@@ -17,7 +17,7 @@ describe('Serverless Collection Tests', () => {
     const template = Template.fromStack(getStack(composer))
     template.resourceCountIs("AWS::OpenSearchServerless::Collection", 1)
     template.hasResourceProperties("AWS::OpenSearchServerless::Collection", {
-      Name: "cluster-unit-test-search", Type: "SEARCH", StandbyReplicas: "ENABLED",
+      Name: "unit-test-search", Type: "SEARCH", StandbyReplicas: "ENABLED",
     })
     template.resourceCountIs("AWS::OpenSearchServerless::SecurityPolicy", 2)
     template.resourceCountIs("AWS::OpenSearchServerless::AccessPolicy", 1)

--- a/test/stack-composer.test.ts
+++ b/test/stack-composer.test.ts
@@ -124,31 +124,29 @@ describe('Stack Composer Tests', () => {
   })
 
   test('Test default clusterName overflow for managed domain produces stage-aware error', () => {
-    // stage under MAX_STAGE_NAME_LENGTH (15) but default pattern 'cluster-<stage>-source'
-    // exceeds the 28-char managed domain limit: cluster-(8) + stage(14) + '-'(1) + 'source'(6) = 29.
+    // With MAX_CLUSTER_ID_LENGTH=15 clusterId: stage(13) + '-'(1) + 15 = 29 > 28
     expect(() => createStackComposer({
-      stage: "fourteen-chars",
-      clusters: [{clusterId: "source", clusterType: ClusterType.OPENSEARCH_MANAGED_SERVICE}]
-    })).toThrow(/'stage' must be at most 13 characters/)
+      stage: "a-13-char-yes",
+      clusters: [{clusterId: "max-length-test", clusterType: ClusterType.OPENSEARCH_MANAGED_SERVICE}]
+    })).toThrow(/'stage' must be at most 12 characters/)
   })
 
   test('Test default clusterName overflow for serverless produces stage-aware error', () => {
-    // cluster-(8) + stage(11) + '-'(1) + target(6) = 26 chars,
-    // but with '-access' suffix for AOSS policy = 33 chars → exceeds 32-char policy limit.
+    // stage(10) + '-'(1) + clusterId(15) = 26 > 25-char AOSS clusterName limit
     expect(() => createStackComposer({
-      stage: "eleven-char",
-      clusters: [{clusterId: "target", clusterType: ClusterType.OPENSEARCH_SERVERLESS}]
-    })).toThrow(/AOSS policy name.*'stage' must be at most 10 characters/s)
+      stage: "10-char-yo",
+      clusters: [{clusterId: "max-length-test", clusterType: ClusterType.OPENSEARCH_SERVERLESS}]
+    })).toThrow(/AOSS policy name.*'stage' must be at most 9 characters/s)
   })
 
   test('Test default clusterName that fits the limit is accepted', () => {
-    // cluster-(8) + stage(13) + '-'(1) + source(6) = 28 chars exactly — at the managed limit.
+    // stage(12) + '-'(1) + clusterId(15) = 28 exactly (at managed limit)
     const composer = createStackComposer({
-      stage: "thirteen-chrs",
-      clusters: [{clusterId: "source", clusterType: ClusterType.OPENSEARCH_MANAGED_SERVICE}]
+      stage: "twelve-chars",
+      clusters: [{clusterId: "max-length-test", clusterType: ClusterType.OPENSEARCH_MANAGED_SERVICE}]
     })
     Template.fromStack(getStack(composer)).hasResourceProperties("AWS::OpenSearchService::Domain", {
-      DomainName: "cluster-thirteen-chrs-source",
+      DomainName: "twelve-chars-max-length-test",
     })
   })
 })


### PR DESCRIPTION
### Description
Follow-up to #137 (deprecation notice) and #138 (v0.3.11 bump): the deprecation of the `cluster-` prefix in the default `clusterName` is now turned into an actual removal.

**What changes:**
- Default `clusterName` pattern: `cluster-<stage>-<clusterId>` → `<stage>-<clusterId>`. The 8-char prefix is gone.
- Deprecation comment + schema description updated to reflect the new default.
- Stage-aware validation error in `parseClusterConfig` now uses the shorter-budget math.
- Tests that relied on the `cluster-` prefix in resource names updated; snapshot regenerated.
- README configuration reference table updated to show the new default.
- CHANGELOG `[0.4.0]` section added with migration guidance.

**Why breaking (bumping to 0.4.0):**
The resource names in AWS change (domain name, AOSS collection name, AOSS policy names) for any consumer that relied on the default. Consumers who set `clusterName` explicitly are unaffected.

**Why now:** The deprecation notice in 0.3.11 was immediately confusing for reviewers ("deprecated" ≠ "changed") and the prefix is dead weight — it's 8 chars of the 28-char managed-domain budget and 25-char AOSS-cluster-name budget with no semantic value.

### Issues Resolved
Completes the deprecation cycle started in #137.

### Testing
- 3 default-path tests in `stack-composer.test.ts` rewritten to use 15-char clusterIds (with 6-char clusterIds the default never overflows post-prefix-removal; needed longer IDs to still trigger the stage-aware error).
- 2 assertion-only test updates for managed + serverless.
- Snapshot regenerated via `vitest -u` — 3 snapshot files updated, all `cluster-*` → `*`.
- `npm run test` — 99/99 passing. `npm run build` — clean.

### Check List
- [x] New functionality includes testing
- [x] Documentation of feature or new context options are documented

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
