### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-service-domain-cdk",
-  "version": "0.3.11",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opensearch-service-domain-cdk",
-      "version": "0.3.11",
+      "version": "0.4.0",
       "dependencies": {
         "aws-cdk-lib": "2.251.0",
         "cdk-nag": "^2.38.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "elasticsearch",
     "infrastructure"
   ],
-  "version": "0.3.11",
+  "version": "0.4.0",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
   "files": [


### PR DESCRIPTION
### Description
Bump version to 0.4.0 to cover the breaking change in #139 (drop `cluster-` prefix from default `clusterName`).

### Issues Resolved
N/A — release bump.

### Testing
N/A — version-string change only. CI runs the full suite against the bumped manifest.

### Check List
- [x] New functionality includes testing
- [x] Documentation of feature or new context options are documented

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.