### PR TITLE
fix: serialize AccessPolicy custom resources across managed domains to avoid IAM propagation race

### DIFF
--- a/lib/components/managed-domain.ts
+++ b/lib/components/managed-domain.ts
@@ -1,4 +1,5 @@
 import {CfnOutput, SecretValue, Stack} from "aws-cdk-lib";
+import {IConstruct} from "constructs";
 import {
     EbsDeviceVolumeType,
     ISecurityGroup,
@@ -19,8 +20,29 @@ import {ManagedClusterConfig} from "./cluster-config";
  * Creates a managed OpenSearch domain within the given stack.
  * This is a helper function, not a separate stack — all resources
  * are created in the caller's stack scope.
+ *
+ * AccessPolicy serialization: when a stack creates multiple managed domains that
+ * each set `accessPolicies`, CDK emits one `Custom::OpenSearchAccessPolicy` per
+ * domain, all backed by the same Lambda role with per-domain IAM policy
+ * attachments. If the policy applications run in parallel, the second domain's
+ * custom resource can fire before its just-attached `es:UpdateDomainConfig`
+ * IAM policy has propagated, producing an `AccessDenied` at deploy time. To
+ * serialize these across calls, the caller threads the previous invocation's
+ * returned `AccessPolicy` construct in via `previousAccessPolicy`; this function
+ * wires a `node.addDependency` edge so each domain's policy application waits
+ * for the previous one to complete (domain creation itself — the slow part —
+ * remains parallel).
+ *
+ * @param previousAccessPolicy  The `AccessPolicy` construct returned by a prior
+ *     `createManagedDomain` call in the same stack, or `undefined` for the first
+ *     call in the chain.
+ * @returns The `AccessPolicy` construct created for this domain (to be threaded
+ *     into the next call), or `undefined` when no AccessPolicy was created —
+ *     either because this is a first-synth dummy-VPC stub (CDK `Vpc.fromLookup`
+ *     returns `vpc-12345` before the context cache is populated) or because
+ *     `accessPolicies` / `openAccessPolicyEnabled` were not set on the config.
  */
-export function createManagedDomain(stack: Stack, config: ManagedClusterConfig, stage: string, vpcDetails?: VpcDetails): void {
+export function createManagedDomain(stack: Stack, config: ManagedClusterConfig, stage: string, vpcDetails?: VpcDetails, previousAccessPolicy?: IConstruct): IConstruct | undefined {
     const prefix = config.clusterId;
 
     // Skip for first synthesis stage (dummy VPC from lookup)
@@ -227,6 +249,13 @@ export function createManagedDomain(stack: Stack, config: ManagedClusterConfig, 
     ]);
 
     generateClusterExports(stack, domain, config.clusterId, stage, vpcDetails?.subnetSelection, vpcDetails?.clusterAccessSecurityGroup?.securityGroupId);
+
+    // Thread AccessPolicy into the serialization chain (see function JSDoc for rationale).
+    const accessPolicy = domain.node.tryFindChild('AccessPolicy');
+    if (accessPolicy && previousAccessPolicy) {
+        accessPolicy.node.addDependency(previousAccessPolicy);
+    }
+    return accessPolicy;
 }
 
 function getEbsVolumeType(ebsVolumeTypeName: string): EbsDeviceVolumeType | undefined {

--- a/lib/opensearch-stack.ts
+++ b/lib/opensearch-stack.ts
@@ -1,4 +1,4 @@
-import {Construct} from "constructs";
+import {Construct, IConstruct} from "constructs";
 import {CfnOutput, Fn, Stack, StackProps, Tags} from "aws-cdk-lib";
 import {
     CfnInternetGateway, CfnNatGateway, CfnEIP, CfnRouteTable,
@@ -63,11 +63,15 @@ export class OpenSearchStack extends Stack {
         }
 
         // --- Managed domains ---
+        // Thread previousAccessPolicy through each call so createManagedDomain can
+        // serialize AccessPolicy custom resources across domains (see managed-domain.ts
+        // for the IAM race rationale).
+        let previousAccessPolicy: IConstruct | undefined;
         for (const config of managedClusters) {
             if (!config.publicAccess && !vpcDetails) {
                 throw new Error("Internal error: VPC details should be resolved for VPC-based managed clusters");
             }
-            createManagedDomain(this, config, stage, config.publicAccess ? undefined : vpcDetails);
+            previousAccessPolicy = createManagedDomain(this, config, stage, config.publicAccess ? undefined : vpcDetails, previousAccessPolicy);
         }
 
         // --- Serverless collections ---

--- a/test/stack-composer.test.ts
+++ b/test/stack-composer.test.ts
@@ -1,4 +1,4 @@
-import { Template } from "aws-cdk-lib/assertions";
+import { Match, Template } from "aws-cdk-lib/assertions";
 import {createStackComposer, createStackComposerWithSingleDomainContext, getStack} from "./test-utils";
 import { describe, afterEach, test, expect, vi } from 'vitest';
 import {ClusterType} from "../lib/components/common-utilities";
@@ -147,6 +147,38 @@ describe('Stack Composer Tests', () => {
     })
     Template.fromStack(getStack(composer)).hasResourceProperties("AWS::OpenSearchService::Domain", {
       DomainName: "twelve-chars-max-length-test",
+    })
+  })
+
+  test('Test AccessPolicy custom resources are serialized across managed domains to avoid IAM propagation race', () => {
+    // When multiple managed domains each have accessPolicies, CDK creates one
+    // Custom::OpenSearchAccessPolicy resource per domain, all sharing the same
+    // Lambda service role. Running them in parallel risks an IAM eventual-consistency
+    // race where the second domain's policy is invoked before its just-attached
+    // es:UpdateDomainConfig permission has propagated. createManagedDomain chains
+    // each AccessPolicy construct to the previous via node.addDependency, forcing
+    // serial execution. This test asserts the resulting CFN DependsOn edge.
+    const samplePolicy = {
+      "Version": "2012-10-17",
+      "Statement": [{
+        "Effect": "Allow",
+        "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+        "Action": "es:*",
+        "Resource": "*"
+      }]
+    }
+    const template = Template.fromStack(getStack(createStackComposer({
+      clusters: [
+        {clusterId: "source", clusterType: ClusterType.OPENSEARCH_MANAGED_SERVICE, publicAccess: true, accessPolicies: samplePolicy},
+        {clusterId: "target", clusterType: ClusterType.OPENSEARCH_MANAGED_SERVICE, publicAccess: true, accessPolicies: samplePolicy},
+      ]
+    })))
+    template.resourceCountIs("Custom::OpenSearchAccessPolicy", 2)
+    // Assert the serialization edge: an AccessPolicy exists whose DependsOn references
+    // another AccessPolicy by logical-id prefix. (CDK derives logical ids from construct
+    // paths, so `sourceDomainAccessPolicy*` is the stable id for source's custom resource.)
+    template.hasResource("Custom::OpenSearchAccessPolicy", {
+      DependsOn: Match.arrayWith([Match.stringLikeRegexp("^sourceDomainAccessPolicy")]),
     })
   })
 })


### PR DESCRIPTION
### Description

Fixes an IAM eventual-consistency race that intermittently causes `Custom::OpenSearchAccessPolicy` to fail with `AccessDenied` on `es:UpdateDomainConfig` when a stack deploys multiple managed domains with access policies in parallel.

**The race:**
CDK's `Domain` L2 construct, when given `accessPolicies`, creates a `Custom::OpenSearchAccessPolicy` AwsCustomResource. For a stack with multiple such domains, CDK shares one Lambda service role across all these custom resources, and attaches per-domain IAM policies (granting `es:UpdateDomainConfig` on that domain) just before each custom resource runs. In parallel execution, the second domain's custom resource can invoke *before* its just-attached IAM policy has fully propagated (IAM is eventually consistent across AWS regions / STS endpoints), producing `AccessDenied`.

**The fix:**
`createManagedDomain` now accepts the previous call's returned `AccessPolicy` construct and wires a `node.addDependency` edge to it. CFN then serializes: domain₁'s IAM policy → domain₁'s custom resource → domain₂'s IAM policy → domain₂'s custom resource. Each IAM policy attachment gets the full duration of the previous custom resource's execution to propagate. The caller in `OpenSearchStack` threads a single `previousAccessPolicy` variable through the loop; see the function's JSDoc for the full rationale.

Domain creation itself (the slow part, ~10 min per domain) remains fully parallel — only the AccessPolicy custom resource phase is serialized, adding ~5–10 s of deployment time per additional domain.

### Issues Resolved

Observed in downstream consumer — CI failure: [pr-eks-cdc-full-e2e-test/90](https://migrations.ci.opensearch.org/job/pr-checks/job/pr-eks-cdc-full-e2e-test/90/).

Target domain's AccessPolicy succeeded (8 s after IAM policy created)
Source domain's failed (2 s after IAM policy created)

### Testing

- New unit test in `test/stack-composer.test.ts` builds a 2-managed-domain stack with explicit access policies, synthesizes CFN, and asserts via the CDK `Template` API (`Match.arrayWith` + `Match.stringLikeRegexp`) that the second domain's `Custom::OpenSearchAccessPolicy` has a `DependsOn` edge on the first domain's AccessPolicy.
- All existing tests still pass. `npm run test` — 100/100 passing.
- `npm run build`, `npm run test:lint` — clean.

### Check List
- [x] New functionality includes testing
- [x] Documentation of feature or new context options are documented

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.