### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 | **0.4.x** | Naming cleanup | Dropped `cluster-` prefix from default `clusterName` |
 | **0.3.x** | Single-stack simplification | 4 stacks → 1 `OpenSearchStack`, removed monitoring + VPC Lambda, discriminated JSON Schema, collection groups, SAML auth, cold storage, deploy script |
 
+## [0.4.1] - 2026-05-12
+
+### Fixed
+- AccessPolicy IAM propagation race when a stack deploys multiple managed OpenSearch domains with `accessPolicies`. CDK's `Custom::OpenSearchAccessPolicy` resources share one Lambda service role across domains; in parallel execution the second domain's custom resource could invoke before its just-attached `es:UpdateDomainConfig` permission had fully propagated, producing `AccessDenied`. `createManagedDomain` now threads a dependency edge between consecutive `AccessPolicy` constructs to serialize policy application while leaving domain creation itself parallel. ([#141](https://github.com/aws-samples/amazon-opensearch-service-sample-cdk/pull/141))
+
 ## [0.4.0] - 2026-05-07
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-service-domain-cdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opensearch-service-domain-cdk",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "aws-cdk-lib": "2.253.1",
         "cdk-nag": "^2.38.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "elasticsearch",
     "infrastructure"
   ],
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
   "files": [


### PR DESCRIPTION
### Description
Patch release bump to v0.4.1. Ships the AccessPolicy IAM propagation race fix from #141.

- CHANGELOG.md: add `[0.4.1] - 2026-05-12` entry under `### Fixed`
- package.json / package-lock.json: `0.4.0` → `0.4.1`

### Issues Resolved
N/A

### Testing
- `npm run build`, `npm run test:lint`, `npm run test:vitest` — all clean, 100/100 passing.

### Check List
- [x] New functionality includes testing
- [x] Documentation of feature or new context options are documented

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
